### PR TITLE
Change to allow the response option to be a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ exports.register = function(server, options, next) {
         method: 'GET',
         path: endpoint,
         handler: function(request, reply) {
-            reply(response);
+            reply((typeof(response) === 'function') ? response() : response);
         },
         config: {
             description: 'Simple endpoint to determine service availability. Returns 200 if successful. No required parameters, simply "ping it"'

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 exports.register = function(server, options, next) {
-    endpoint = options.endpoint || '/ping';
-    response = options.response || 'Success';
+    var endpoint = options.endpoint || '/ping';
+    var response = options.response || 'Success';
 
     server.route({
         method: 'GET',

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,25 @@ Simply install with npm and go!
 
     npm install hapi-ping
 
-### Usage
+## Usage
 Usage is very simple, simply register it as a hapi plugin, and the route will be added to your service.
 Optionally, you can override the endpoint with the "endpoint" option. You can also configure what the response
 body will be when the service is successful. (Generally I just return the services package.json contents, as it
     makes it easy to get service version information etc);
 
-### Example
+## Plugin Options
+
+### `endpoint`
+
+The route to expose the ping functionality on.
+
+Defaults to `'/ping'`
+
+### `response`
+
+The response to send when an incoming request hits the ping endpoint. This can be any type of object that hapi's `reply` interface accepts or a function that returns any type of object that hapi's `reply` interface accepts. Set this to a function if the desire is to return dynamic data. Defaults to `'Success'`
+
+## Example
 ```javascript
     var server = new Hapi.Server();
 

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,9 @@ Defaults to `'/ping'`
 
 ### `response`
 
-The response to send when an incoming request hits the ping endpoint. This can be any type of object that hapi's `reply` interface accepts or a function that returns any type of object that hapi's `reply` interface accepts. Set this to a function if the desire is to return dynamic data. Defaults to `'Success'`
+The response to send when an incoming request hits the ping endpoint. This can be any type of object that hapi's `reply` interface accepts or a function that returns any type of object that hapi's `reply` interface accepts. Set this to a function if the desire is to return dynamic data.
+
+Defaults to `'Success'`
 
 ## Example
 ```javascript


### PR DESCRIPTION
This is useful to be able to return data like `process.uptime()` or `process.memoryUsage()` or any other data that let's you dynamically determine the health of the app.
